### PR TITLE
Added resume_video()

### DIFF
--- a/adafruit_vc0706.py
+++ b/adafruit_vc0706.py
@@ -188,6 +188,12 @@ class VC0706:
         """
         self._frame_ptr = 0
         return self._run_command(_FBUF_CTRL, bytes([0x1, _STOPCURRENTFRAME]), 5)
+    
+    def resume_video(self):
+        """Tell the camera to resume being a camera after the video has stopped
+        (Such as what happens when a picture is taken).
+        """
+        return self._run_command(_FBUF_CTRL, bytes([0x1, _RESUMEFRAME]), 5)
 
     def read_picture_into(self, buf):
         """Read the next bytes of frame/picture data into the provided buffer.

--- a/adafruit_vc0706.py
+++ b/adafruit_vc0706.py
@@ -95,8 +95,8 @@ _CAMERA_DELAY = const(10)
 
 class VC0706:
     """Driver for VC0706 serial TTL camera module.
-       :param ~busio.UART uart: uart serial or compatible interface
-       :param int buffer_size: Receive buffer size
+    :param ~busio.UART uart: uart serial or compatible interface
+    :param int buffer_size: Receive buffer size
     """
 
     def __init__(self, uart, *, buffer_size=100):
@@ -148,7 +148,7 @@ class VC0706:
     @property
     def image_size(self):
         """Get the current image size, will return a value of IMAGE_SIZE_640x480,
-           IMAGE_SIZE_320x240, or IMAGE_SIZE_160x120.
+        IMAGE_SIZE_320x240, or IMAGE_SIZE_160x120.
         """
         if not self._run_command(_READ_DATA, b"\0x04\x04\x01\x00\x19", 6):
             raise RuntimeError("Failed to read image size!")
@@ -157,7 +157,7 @@ class VC0706:
     @image_size.setter
     def image_size(self, size):
         """Set the image size to a value of IMAGE_SIZE_640x480, IMAGE_SIZE_320x240, or
-           IMAGE_SIZE_160x120.
+        IMAGE_SIZE_160x120.
         """
         if size not in (IMAGE_SIZE_640x480, IMAGE_SIZE_320x240, IMAGE_SIZE_160x120):
             raise ValueError(
@@ -170,8 +170,7 @@ class VC0706:
 
     @property
     def frame_length(self):
-        """Return the length in bytes of the currently capture frame/picture.
-        """
+        """Return the length in bytes of the currently capture frame/picture."""
         if not self._run_command(_GET_FBUF_LEN, b"\x01\x00", 9):
             return 0
         frame_length = self._buffer[5]
@@ -184,11 +183,10 @@ class VC0706:
         return frame_length
 
     def take_picture(self):
-        """Tell the camera to take a picture.  Returns True if successful.
-        """
+        """Tell the camera to take a picture.  Returns True if successful."""
         self._frame_ptr = 0
         return self._run_command(_FBUF_CTRL, bytes([0x1, _STOPCURRENTFRAME]), 5)
-    
+
     def resume_video(self):
         """Tell the camera to resume being a camera after the video has stopped
         (Such as what happens when a picture is taken).

--- a/examples/vc0706_snapshot_filesystem.py
+++ b/examples/vc0706_snapshot_filesystem.py
@@ -63,6 +63,8 @@ print("Picture size (bytes): {}".format(frame_length))
 # You MUST keep the buffer size under 100!
 print("Writing image: {}".format(IMAGE_FILE), end="", flush=True)
 stamp = time.monotonic()
+#Pylint doesn't like the wcount variable being lowercase, but uppercase makes less sense
+# pylint: disable=invalid-name
 with open(IMAGE_FILE, "wb") as outfile:
     wcount = 0
     while frame_length > 0:
@@ -84,6 +86,7 @@ with open(IMAGE_FILE, "wb") as outfile:
             print(".", end="", flush=True)
             wcount = 0
 print()
+# pylint: enable=invalid-name
 print("Finished in %0.1f seconds!" % (time.monotonic() - stamp))
-#Turn the camera back into video mode.
+# Turn the camera back into video mode.
 vc0706.resume_video()

--- a/examples/vc0706_snapshot_filesystem.py
+++ b/examples/vc0706_snapshot_filesystem.py
@@ -63,7 +63,7 @@ print("Picture size (bytes): {}".format(frame_length))
 # You MUST keep the buffer size under 100!
 print("Writing image: {}".format(IMAGE_FILE), end="", flush=True)
 stamp = time.monotonic()
-#Pylint doesn't like the wcount variable being lowercase, but uppercase makes less sense
+# Pylint doesn't like the wcount variable being lowercase, but uppercase makes less sense
 # pylint: disable=invalid-name
 with open(IMAGE_FILE, "wb") as outfile:
     wcount = 0

--- a/examples/vc0706_snapshot_filesystem.py
+++ b/examples/vc0706_snapshot_filesystem.py
@@ -85,3 +85,5 @@ with open(IMAGE_FILE, "wb") as outfile:
             wcount = 0
 print()
 print("Finished in %0.1f seconds!" % (time.monotonic() - stamp))
+#Turn the camera back into video mode.
+vc0706.resume_video()

--- a/examples/vc0706_snapshot_simpletest.py
+++ b/examples/vc0706_snapshot_simpletest.py
@@ -73,6 +73,7 @@ print("Picture size (bytes): {}".format(frame_length))
 # You MUST keep the buffer size under 100!
 print("Writing image: {}".format(IMAGE_FILE), end="")
 stamp = time.monotonic()
+# pylint: disable=invalid-name
 with open(IMAGE_FILE, "wb") as outfile:
     wcount = 0
     while frame_length > 0:
@@ -92,7 +93,8 @@ with open(IMAGE_FILE, "wb") as outfile:
         if wcount >= 64:
             print(".", end="")
             wcount = 0
+# pylint: enable=invalid-name
 print()
 print("Finished in %0.1f seconds!" % (time.monotonic() - stamp))
-#Turn the camera back into video mode.
+# Turn the camera back into video mode.
 vc0706.resume_video()

--- a/examples/vc0706_snapshot_simpletest.py
+++ b/examples/vc0706_snapshot_simpletest.py
@@ -33,7 +33,7 @@ vfs = storage.VfsFat(sdcard)
 storage.mount(vfs, "/sd")
 
 # Create a serial connection for the VC0706 connection, speed is auto-detected.
-uart = busio.UART(board.TX, board.RX, timeout=250)
+uart = busio.UART(board.TX, board.RX)
 # Setup VC0706 camera
 vc0706 = adafruit_vc0706.VC0706(uart)
 
@@ -72,6 +72,7 @@ print("Picture size (bytes): {}".format(frame_length))
 # This will write 50 bytes at a time using a small buffer.
 # You MUST keep the buffer size under 100!
 print("Writing image: {}".format(IMAGE_FILE), end="")
+stamp = time.monotonic()
 with open(IMAGE_FILE, "wb") as outfile:
     wcount = 0
     while frame_length > 0:
@@ -92,4 +93,6 @@ with open(IMAGE_FILE, "wb") as outfile:
             print(".", end="")
             wcount = 0
 print()
-print("Finished!")
+print("Finished in %0.1f seconds!" % (time.monotonic() - stamp))
+#Turn the camera back into video mode.
+vc0706.resume_video()


### PR DESCRIPTION
Added resume_video() which restarts the framebuffer. Added it to the examples. Also adjusted the SD example to show time like the original, and removed the timeout that was too large.

Addresses issue #16 