### PR TITLE
set_motion_detection docstring and argument name

### DIFF
--- a/adafruit_vc0706.py
+++ b/adafruit_vc0706.py
@@ -225,11 +225,12 @@ class VC0706:
         """Query the gesture detection status"""
         return self._run_command(_COMM_MOTION_STATUS, bytes([0x00]), 6)
 
-    def set_motion_detect(self, args):
+    def set_motion_detect(self, enabled):
         """Set gesture detection status.
-        args = 0 to unset, 1 to set
+
+        :param bool enabled: False to disable motion detected, True to enable motion detection.
         """
-        return self._run_command(_COMM_MOTION_CTRL, bytes([0x01, args]), 5)
+        return self._run_command(_COMM_MOTION_CTRL, bytes([0x01, enabled]), 5)
 
     def _run_command(self, cmd, args, resplen, flush=True):
         if flush:


### PR DESCRIPTION
Changing the name of this argument to be more descriptive and adding docstring syntax to make it appear nice in docs pages. Also more specifically suggest boolean for type instead of `0` and `1`. 

I didn't know these were this interchangeable but tested like this and it appears either should work the same:
```py
>>> bytes([0x01, True])
b'\x01\x01'
>>> bytes([0x01, False])
b'\x01\x00'
>>> bytes([0x01, 0])
b'\x01\x00'
>>> bytes([0x01, 1])
b'\x01\x01'
```