### PR TITLE
Breaking changes to conform to design guide

### DIFF
--- a/adafruit_vc0706.py
+++ b/adafruit_vc0706.py
@@ -221,15 +221,13 @@ class VC0706:
             return False
         return True
 
-    def get_motion_detect(self):
-        """Query the gesture detection status"""
+    @property
+    def motion_detection(self):
+        """The gesture detection status"""
         return self._run_command(_COMM_MOTION_STATUS, bytes([0x00]), 6)
 
-    def set_motion_detect(self, enabled):
-        """Set gesture detection status.
-
-        :param bool enabled: False to disable motion detected, True to enable motion detection.
-        """
+    @motion_detection.setter
+    def motion_detection(self, enabled):
         return self._run_command(_COMM_MOTION_CTRL, bytes([0x01, enabled]), 5)
 
     def _run_command(self, cmd, args, resplen, flush=True):

--- a/adafruit_vc0706.py
+++ b/adafruit_vc0706.py
@@ -214,8 +214,9 @@ class VC0706:
             buf[i] = self._buffer[i]
         return n
 
+    @property
     def motion_detected(self):
-        """Read the gesture detection result"""
+        """Whether a gesture was detected"""
         self._read_response(self._buffer, len(self._buffer))
         if not self._verify_response(_COMM_MOTION_DETECTED):
             return False


### PR DESCRIPTION
These changes resolve #24 by turning methods into properties.  This seems to be more inline with the design guide for CircuitPython, since these seem to be more like "states" as opposed to "actions".

It doesn't look like the product tutorial needs any changing, since it didn't go over motion detection.